### PR TITLE
Replaced deprecated policy. https://docs.aws.amazon.com/lambda/latest…

### DIFF
--- a/cfn/text-cm-update.yaml
+++ b/cfn/text-cm-update.yaml
@@ -26,7 +26,7 @@ Resources:
         - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSQSFullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
-        - 'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+        - 'arn:aws:iam::aws:policy/AWSLambda_FullAccess'
         - 'arn:aws:iam::aws:policy/AmazonTextractFullAccess'
         - 'arn:aws:iam::aws:policy/ComprehendMedicalFullAccess'
         - 'arn:aws:iam::aws:policy/CloudWatchFullAccess'

--- a/cfn/text-cm.yaml
+++ b/cfn/text-cm.yaml
@@ -26,7 +26,7 @@ Resources:
         - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSQSFullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
-        - 'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+        - 'arn:aws:iam::aws:policy/AWSLambda_FullAccess'
         - 'arn:aws:iam::aws:policy/AmazonTextractFullAccess'
         - 'arn:aws:iam::aws:policy/ComprehendMedicalFullAccess'
         - 'arn:aws:iam::aws:policy/CloudWatchFullAccess'


### PR DESCRIPTION
…/dg/access-control-identity-based.html for more info

*Issue #, if available:*

IAM policy defined in CF template is now defunct: https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html

*Description of changes:*

Replaced name of policy with revised policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
